### PR TITLE
perf: eliminate full table scans in guardian health and totals queries

### DIFF
--- a/fmo_server/schema/v9.sql
+++ b/fmo_server/schema/v9.sql
@@ -1,0 +1,75 @@
+-- Incrementally maintained per-federation totals
+BEGIN;
+
+INSERT INTO schema_version (version)
+VALUES (9);
+
+-- Wait for in-flight writers to finish and block new ones, so that no rows can slip
+-- through between the seed below and the triggers becoming visible to other backends.
+LOCK TABLE transactions, transaction_inputs IN SHARE MODE;
+
+-- Deliberately has no secondary indexes: the table holds one row per federation but is
+-- updated once per inserted transaction/input, so we want updates to stay HOT.
+CREATE TABLE IF NOT EXISTS federation_totals (
+    federation_id BYTEA PRIMARY KEY REFERENCES federations (federation_id),
+    tx_count BIGINT NOT NULL DEFAULT 0,
+    tx_volume_msat BIGINT NOT NULL DEFAULT 0
+);
+
+-- One dead tuple per inserted transaction/input, on a table of a handful of rows. Without
+-- this the default scale factor (20% of a ~17 row table) would never trigger a vacuum in
+-- time and the table would bloat far out of proportion to its logical size.
+ALTER TABLE federation_totals
+    SET (
+        autovacuum_vacuum_scale_factor = 0.0,
+        autovacuum_vacuum_threshold = 100,
+        autovacuum_analyze_scale_factor = 0.0,
+        autovacuum_analyze_threshold = 100
+    );
+
+CREATE OR REPLACE FUNCTION federation_totals_count_tx() RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO federation_totals (federation_id, tx_count)
+    VALUES (NEW.federation_id, 1)
+    ON CONFLICT (federation_id) DO UPDATE
+        SET tx_count = federation_totals.tx_count + 1;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- amount_msat is NULL for input kinds other than ln/mint/wallet. SUM() skips NULLs, so
+-- coalesce to 0 to match the aggregate this replaces.
+CREATE OR REPLACE FUNCTION federation_totals_add_volume() RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO federation_totals (federation_id, tx_volume_msat)
+    VALUES (NEW.federation_id, COALESCE(NEW.amount_msat, 0))
+    ON CONFLICT (federation_id) DO UPDATE
+        SET tx_volume_msat = federation_totals.tx_volume_msat + COALESCE(NEW.amount_msat, 0);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Row level AFTER INSERT triggers do not fire for rows skipped by ON CONFLICT DO NOTHING,
+-- which is what keeps these counters correct when a session gets reprocessed.
+CREATE TRIGGER transactions_bump_totals
+    AFTER INSERT ON transactions
+    FOR EACH ROW EXECUTE FUNCTION federation_totals_count_tx();
+
+CREATE TRIGGER transaction_inputs_bump_totals
+    AFTER INSERT ON transaction_inputs
+    FOR EACH ROW EXECUTE FUNCTION federation_totals_add_volume();
+
+INSERT INTO federation_totals (federation_id, tx_count, tx_volume_msat)
+SELECT f.federation_id,
+       (SELECT COUNT(*)
+        FROM transactions t
+        WHERE t.federation_id = f.federation_id),
+       (SELECT COALESCE(SUM(ti.amount_msat), 0)
+        FROM transaction_inputs ti
+        WHERE ti.federation_id = f.federation_id)
+FROM federations f
+ON CONFLICT (federation_id) DO UPDATE
+    SET tx_count = EXCLUDED.tx_count,
+        tx_volume_msat = EXCLUDED.tx_volume_msat;
+
+COMMIT;

--- a/fmo_server/src/federation/guardians.rs
+++ b/fmo_server/src/federation/guardians.rs
@@ -123,21 +123,45 @@ impl FederationObserver {
 
         let health_rows = query::<GuardianHealthRow>(
             &self.connection().await?,
+            // The `guardians` CTE emulates an index skip-scan over the
+            // (federation_id, guardian_id, time) index to enumerate the
+            // federation's guardian ids. Naively grouping by guardian_id to get
+            // the latest row per guardian instead degenerates into a full scan
+            // of the (large) guardian_health table, since PostgreSQL has no
+            // native skip-scan. With the guardian ids known we can fetch each
+            // latest row with a single index descent.
             // language=postgresql
-            "SELECT
-                latest.guardian_id,
+            "WITH RECURSIVE guardians AS (
+                 SELECT (SELECT h.guardian_id
+                         FROM guardian_health h
+                         WHERE h.federation_id = $1
+                         ORDER BY h.guardian_id
+                         LIMIT 1) AS guardian_id
+               UNION ALL
+                 SELECT (SELECT h.guardian_id
+                         FROM guardian_health h
+                         WHERE h.federation_id = $1
+                           AND h.guardian_id > g.guardian_id
+                         ORDER BY h.guardian_id
+                         LIMIT 1)
+                 FROM guardians g
+                 WHERE g.guardian_id IS NOT NULL
+             )
+             SELECT
+                g.guardian_id,
                 latest.block_height,
                 (latest.status -> 'federation' ->> 'session_count')::integer AS session_count,
                 last30d.uptime,
                 last30d.latency_ms
-             FROM guardian_health latest
-             INNER JOIN (
-                 SELECT guardian_id, MAX(time) as latest_time
-                 FROM guardian_health
-                 WHERE federation_id = $1
-                 GROUP BY guardian_id
-             ) max_times ON latest.guardian_id = max_times.guardian_id
-                           AND latest.time = max_times.latest_time
+             FROM guardians g
+             CROSS JOIN LATERAL (
+                 SELECT h.block_height, h.status
+                 FROM guardian_health h
+                 WHERE h.federation_id = $1
+                   AND h.guardian_id = g.guardian_id
+                 ORDER BY h.time DESC
+                 LIMIT 1
+             ) latest
              INNER JOIN (
                  SELECT
                      guardian_id,
@@ -147,8 +171,8 @@ impl FederationObserver {
                  WHERE federation_id = $1
                    AND time > NOW() - INTERVAL '30 days'
                  GROUP BY guardian_id
-             ) last30d ON latest.guardian_id = last30d.guardian_id
-             WHERE latest.federation_id = $1",
+             ) last30d ON g.guardian_id = last30d.guardian_id
+             WHERE g.guardian_id IS NOT NULL",
             &[&federation_id.consensus_encode_to_vec()],
         )
         .await?;
@@ -199,21 +223,45 @@ impl FederationObserver {
 
         let federations = query::<FederationHealthRow>(
             &self.connection().await?,
+            // See `get_guardian_health` for why the guardian ids are enumerated
+            // with a recursive CTE instead of grouping over guardian_health:
+            // it emulates the index skip-scan PostgreSQL lacks, turning a full
+            // table scan into a handful of index descents.
             // language=postgresql
-            "SELECT
-                gh.federation_id,
-                COUNT(DISTINCT gh.guardian_id)::int as guardians,
-                COUNT(DISTINCT CASE WHEN gh.status -> 'federation' ->> 'session_count' IS NOT NULL
-                                   THEN gh.guardian_id END)::int as online_guardians
-             FROM guardian_health gh
-             INNER JOIN (
-                 SELECT federation_id, guardian_id, MAX(time) as latest_time
-                 FROM guardian_health
-                 GROUP BY federation_id, guardian_id
-             ) latest ON gh.federation_id = latest.federation_id
-                        AND gh.guardian_id = latest.guardian_id
-                        AND gh.time = latest.latest_time
-             GROUP BY gh.federation_id",
+            "WITH RECURSIVE guardians AS (
+                 SELECT f.federation_id,
+                        (SELECT h.guardian_id
+                         FROM guardian_health h
+                         WHERE h.federation_id = f.federation_id
+                         ORDER BY h.guardian_id
+                         LIMIT 1) AS guardian_id
+                 FROM federations f
+               UNION ALL
+                 SELECT g.federation_id,
+                        (SELECT h.guardian_id
+                         FROM guardian_health h
+                         WHERE h.federation_id = g.federation_id
+                           AND h.guardian_id > g.guardian_id
+                         ORDER BY h.guardian_id
+                         LIMIT 1)
+                 FROM guardians g
+                 WHERE g.guardian_id IS NOT NULL
+             )
+             SELECT
+                g.federation_id,
+                COUNT(*)::int as guardians,
+                COUNT(*) FILTER (WHERE latest.status -> 'federation' ->> 'session_count' IS NOT NULL)::int as online_guardians
+             FROM guardians g
+             CROSS JOIN LATERAL (
+                 SELECT h.status
+                 FROM guardian_health h
+                 WHERE h.federation_id = g.federation_id
+                   AND h.guardian_id = g.guardian_id
+                 ORDER BY h.time DESC
+                 LIMIT 1
+             ) latest
+             WHERE g.guardian_id IS NOT NULL
+             GROUP BY g.federation_id",
             &[],
         )
         .await?;

--- a/fmo_server/src/federation/observer.rs
+++ b/fmo_server/src/federation/observer.rs
@@ -191,6 +191,7 @@ impl FederationObserver {
                 "/schema/v8.sql",
                 FederationObserver::backfill_reprocess_all_sessions
             ),
+            migration!("/schema/v9.sql"),
         ];
 
         for (index, migration) in migrations.iter().enumerate() {
@@ -1403,13 +1404,17 @@ impl FederationObserver {
             .filter(|&health| *health == FederationHealth::Offline)
             .count() as u64;
 
+        // Reads the counters maintained by the triggers introduced in v9 instead of
+        // aggregating over `transactions` and `transaction_inputs`, which meant a full
+        // scan of both tables (~1.3GB) on every request.
         let totals = query_one::<FedimintTotalsResult>(
             &self.connection().await?,
             // language=postgresql
             "
-                SELECT (SELECT count(*) from federations)::bigint               as federations,
-                       (SELECT count(*) from transactions)::bigint               as tx_count,
-                       (SELECT sum(amount_msat) from transaction_inputs)::bigint as tx_volume
+                SELECT (SELECT count(*) from federations)::bigint as federations,
+                       COALESCE(sum(tx_count), 0)::bigint         as tx_count,
+                       COALESCE(sum(tx_volume_msat), 0)::bigint   as tx_volume
+                FROM federation_totals
             ",
             &[],
         )


### PR DESCRIPTION
Three endpoints were spending seconds sequentially scanning large tables to produce a handful of rows. All of them are hit on every page load, which is why the public instance needs aggressive nginx caching to stay usable.

Measured on the production database (~24 GB; `guardian_health` alone is 13 GB / 16.1M rows).

## 1. `get_guardian_health_summary` — 15.5s

The inner subquery had no `WHERE` clause:

```sql
SELECT federation_id, guardian_id, MAX(time) FROM guardian_health GROUP BY federation_id, guardian_id
```

PostgreSQL has no index skip-scan, so this cannot use `(federation_id, guardian_id, time)` and degenerates into a full scan:

```
Parallel Seq Scan on guardian_health (actual time=1.099..13509.849 rows=5380998 loops=3)
  Buffers: shared hit=19 read=1115178
Execution Time: 15458.636 ms
```

8.7 GB read from disk, at a ~100% cache miss rate, to return **67 rows**. It runs on both `/federations` and `/federations/totals`.

Replaced with a recursive CTE that emulates a skip-scan over `(federation_id, guardian_id)`, plus a `LATERAL ... ORDER BY time DESC LIMIT 1` per pair:

| | buffers | time |
|---|---|---|
| before | 1,115,614 | 13,446 ms |
| after (cold) | 4,686 | 1,081 ms |
| after (warm) | — | **19.2 ms** |

**~238x fewer buffers.**

## 2. `get_guardian_health` — 8.2s

Same anti-pattern scoped to one federation. Its `max_times` subquery scanned that federation's entire history to return 4 rows:

```
Parallel Index Only Scan ... (actual time=47.709..5528.126 rows=326661 loops=3)
  Heap Fetches: 120324
Execution Time: 8237.969 ms
```

Same rewrite. The `last30d` uptime aggregate is deliberately untouched — it is inherent to the semantics, and it accounts for essentially all of the remaining cost.

| federation | before | after |
|---|---|---|
| 4 guardians | 182,379 buf / 3,007 ms | 50,170 buf / 310 ms |
| 6 guardians | 242,272 buf / 6,117 ms | 44,451 buf / 334 ms |
| 1 guardian | 26,267 buf / 615 ms | 14,424 buf / 56 ms |

## 3. `/federations/totals` — 4.5s

Recomputed `count(*)` over `transactions` and `sum(amount_msat)` over `transaction_inputs` on every request — sequential scans of ~1.3 GB.

Adds a `federation_totals` table (schema v9) holding one row per federation, maintained by `AFTER INSERT` triggers. Both source tables are append-only, so counters only ever increment.

Three design points worth reviewing:

- **Sharded per federation, not a single global row.** Ingest runs one concurrent task per federation; a single counter row would serialize all of them on one row lock.
- **Row-level triggers, not statement-level.** The ingest inserts are all `ON CONFLICT DO NOTHING`, and an `AFTER INSERT` row trigger does not fire for a skipped row — so reprocessing a session (e.g. via `/backfill`) leaves the counters untouched. Accumulating the same numbers in `process_session` instead would double count on every replay. Statement-level triggers would buy nothing here anyway, since the inserts are already one row per statement.
- **`amount_msat` is nullable** and `SUM()` skips NULLs, so the volume trigger coalesces to 0 to preserve the semantics of the aggregate it replaces.

The table has no secondary indexes (so updates stay HOT) and carries aggressive per-table autovacuum settings, since it takes one dead tuple per inserted row.

## Verification

**Queries 1 and 2** — original and rewritten forms were run against the production database and the results diffed:

- Query 1: all 17 federations, byte-identical.
- Query 2: run per federation for all 17, with both forms executed inside a single `REPEATABLE READ` transaction so `NOW()` and the MVCC snapshot matched (the table is written every 60s, so separate runs would drift). Identical for every federation, including a 1-guardian federation and an all-offline one.

The `COUNT(DISTINCT ...)` to `COUNT(*)` change is safe by construction, not just empirically: the primary key is `(federation_id, guardian_id, time)`, so the max-time row per pair is unique and the old `INNER JOIN ... time = latest_time` could never fan out.

**Migration v9** — tested end to end against a local PostgreSQL:

- v0 through v9 apply cleanly to a fresh database.
- Replaying an entire session's inserts leaves the counters completely unchanged, while a genuinely new row afterwards is still counted.
- NULL `amount_msat` contributes 0; zero drift against a full recomputation.
- Migrating a database that already contains data (the actual production path) reproduces the pre-migration totals exactly, and a federation with no transactions gets a `0/0` row rather than being skipped.

**In production**, after deploying, the trigger-maintained counters were checked against a full recomputation with ingest running live:

```
new_tx_count | old_tx_count |   new_volume   |   old_volume
     1015497 |      1015497 | 10972600178146 | 10972600178146
```

Zero drift on all 17 federations.

End-to-end endpoint latency, measured directly against the backend with nginx bypassed:

| endpoint | before | after (warm) |
|---|---|---|
| `/federations` | 14.16 s | 0.12 s |
| `/federations/totals` | 13.52 s | 0.017 s |
| `/federations/{id}/health` | 4.38 s | 0.38 s |

Host load average went from 25/33/33 to under 3.

## Notes for reviewers

- The v9 migration seeds by aggregating the existing tables, which takes ~25s on the production dataset and holds a `SHARE` lock on `transactions` and `transaction_inputs` while it runs. One-time, at the startup that applies it.
- `transaction_histogram` and the N+1 in `list_federation_summaries` are untouched and remain the next candidates.
- `guardian_health_federation_guardian_time` is an exact duplicate of the primary key and wastes 1.9 GB. Not addressed here to keep this reviewable, but worth dropping.
