### PR TITLE
fix: remove legacy Darwin SDK framework

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
         };
         flakeboxLib = flakebox.lib.mkLib pkgs { };
         lib = pkgs.lib;
-        stdenv = pkgs.stdenv;
 
         toolchains = flakeboxLib.mkFenixToolchain {
           components = [
@@ -151,8 +150,6 @@
             pkgs.nixpkgs-fmt
             # cmake is required for building aws-lc-sys (fedimint dependency)
             pkgs.cmake
-          ] ++ lib.optionals stdenv.isDarwin [
-            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
           ];
 
           shellHook = ''


### PR DESCRIPTION
Remove the obsolete darwin.apple_sdk framework reference so nix develop works with current nixpkgs on macOS.